### PR TITLE
Install manpage for gluster binary

### DIFF
--- a/debian/glusterfs-server.manpages
+++ b/debian/glusterfs-server.manpages
@@ -1,2 +1,2 @@
-# debian/tmp/usr/share/man/man8/gluster.8
+debian/tmp/usr/share/man/man8/gluster.8
 # debian/tmp/usr/share/man/man8/glusterd.8


### PR DESCRIPTION
Looking at glusterfs-3.3.1/doc/Makefile.am, I'm guessing gluster.8 can be installed in the package.

It would certainly be useful as reference for the server binary.
