### PR TITLE
Post-rotate script sends HUP to Gluster daemons

### DIFF
--- a/debian/glusterfs-common.logrotate
+++ b/debian/glusterfs-common.logrotate
@@ -1,8 +1,16 @@
-/var/log/glusterfs/*.log {
+/var/log/glusterfs/*.log
+/var/log/glusterfs/bricks/*.log
+/var/log/glusterfs/geo-replication/*.log
+/var/log/glusterfs/geo-replication-slaves/*.log
+{
 	daily
 	rotate 7
 	delaycompress
 	compress
 	notifempty
 	missingok
+	sharedscripts
+	postrotate
+		pgrep glusterfs | xargs --no-run-if-empty kill -HUP
+	endscript
 }


### PR DESCRIPTION
This script will send HUP to all running processes that match '_glusterfs_'.
That's not great, but I guess SIGHUP is pretty safe.
